### PR TITLE
Manual invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ Follow the instruction from the following command:
 bash ./bin/configure.sh
 ```
 
+## Manual invocation
+
+Sometimes, you might need to enable your non-production ECS cluster manually.
+Please, use the following command to start your cluster:
+```shell
+bash bin/manually.sh start ECS_CLUSTER_NAME
+```
+or to stop:
+```shell
+bash bin/manually.sh stop ECS_CLUSTER_NAME
+```
+
 ## Code and Configs
 
 

--- a/bin/manually.sh
+++ b/bin/manually.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -x
+
+aws lambda invoke \
+	--cli-binary-format raw-in-base64-out \
+	--function-name ScalingLambda \
+	--invocation-type Event \
+	--payload '{ "action":"'${1}'", "cluster":"'${2}'" }' \
+	response.json

--- a/main.yaml
+++ b/main.yaml
@@ -85,7 +85,7 @@ Resources:
     Properties: 
       Description: Starts at 8 AM on workdays
       Name: StartEcsServicesRule
-      ScheduleExpression: 'cron(30 1 ? * * *)' # 8AM MMT
+      ScheduleExpression: 'cron(30 1 ? * MON-FRI *)' # 8AM MMT
       State: ENABLED
       Targets:  
         - Arn: !GetAtt ScalingLambda.Arn

--- a/main.yaml
+++ b/main.yaml
@@ -19,7 +19,7 @@ Parameters:
   EcsFullPermissionRole:
     Type: String
     Description: ARN of the AWS managed IAM Role for ECS Full Access permissions e.g arn:aws:iam::aws:policy/AmazonECS_FullAccess
-    Default: "XXX"
+    Default: "arn:aws:iam::aws:policy/AmazonECS_FullAccess"
 
   ClusterName:
     Type: String


### PR DESCRIPTION
## Purpose
- Add manual invocation
- Set the schedule to skip the start on weekends

## Overview
- Provided instruction in README on how to start ECS cluster manually
- Set the schedule to skip the start on weekends

## Impact
The schedule might stop working.

## Rollback
Revert the PR and redeploy the CloudFormation template

## Test
Tested manually