### PR TITLE
Parameterize Schedule Expression to avoid rebuilding entire CloudFormation template

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ bash ./bin/configure.sh
 
 ## Manual invocation
 
-Sometimes, you might need to enable your non-production ECS cluster manually.
+Sometimes, you might need to start non-production ECS cluster manually.
 Please, use the following command to start your cluster:
 ```shell
 bash bin/manually.sh start ECS_CLUSTER_NAME

--- a/main.yaml
+++ b/main.yaml
@@ -8,24 +8,24 @@
 Parameters:
   CodeBucket:
     Type: String
-    Description: Bucket where the python code for lambda is saved
+    Description: Bucket where the python code for lambda is saved.
     MinLength: 3
     MaxLength: 63
     AllowedPattern: ^[a-zA-Z0-9]*$
 
   CodeKey:
     Type: String
-    Description: The S3 object key
+    Description: The S3 object key.
     Default: "lambda_function.zip"
 
   EcsFullPermissionRole:
     Type: String
-    Description: ARN of the AWS managed IAM Role for ECS Full Access permissions e.g., arn:aws:iam::aws:policy/AmazonECS_FullAccess
+    Description: ARN of the AWS managed IAM Role for ECS Full Access permissions e.g., arn:aws:iam::aws:policy/AmazonECS_FullAccess.
     Default: "arn:aws:iam::aws:policy/AmazonECS_FullAccess"
 
   ClusterName:
     Type: String
-    Description: Name of the ECS Cluster
+    Description: Name of the ECS Cluster.
     MinLength: 3
 
   StartAt:

--- a/main.yaml
+++ b/main.yaml
@@ -94,7 +94,7 @@ Resources:
   StartEcsServicesRuleCloudwatch:
     Type: AWS::Events::Rule
     Properties: 
-      Description: Starts at 8 AM on workdays
+      Description: Starts only weekdays
       Name: StartEcsServicesRule
       ScheduleExpression: !Ref StartAt
       State: ENABLED
@@ -107,7 +107,7 @@ Resources:
   StopEcsServicesRuleCloudwatch:
     Type: AWS::Events::Rule
     Properties: 
-      Description: Stops at 1 AM on workdays
+      Description: Stops daily
       Name: StopEcsServicesRule
       ScheduleExpression: !Ref StopAt
       State: ENABLED

--- a/main.yaml
+++ b/main.yaml
@@ -11,7 +11,6 @@ Parameters:
     Description: Bucket where the python code for lambda is saved.
     MinLength: 3
     MaxLength: 63
-    AllowedPattern: ^[a-zA-Z0-9]*$
 
   CodeKey:
     Type: String

--- a/main.yaml
+++ b/main.yaml
@@ -9,7 +9,9 @@ Parameters:
   CodeBucket:
     Type: String
     Description: Bucket where the python code for lambda is saved
-    Default: "XXX"
+    MinLength: 3
+    MaxLength: 63
+    AllowedPattern: ^[a-zA-Z0-9]*$
 
   CodeKey:
     Type: String
@@ -18,13 +20,23 @@ Parameters:
 
   EcsFullPermissionRole:
     Type: String
-    Description: ARN of the AWS managed IAM Role for ECS Full Access permissions e.g arn:aws:iam::aws:policy/AmazonECS_FullAccess
+    Description: ARN of the AWS managed IAM Role for ECS Full Access permissions e.g., arn:aws:iam::aws:policy/AmazonECS_FullAccess
     Default: "arn:aws:iam::aws:policy/AmazonECS_FullAccess"
 
   ClusterName:
     Type: String
     Description: Name of the ECS Cluster
-    Default: "XXX"
+    MinLength: 3
+
+  StartAt:
+    Type: String
+    Description: ScheduleExpression value e.g., 'cron(30 1 ? * MON-FRI *)' or 'rate(1 day)'. Default is start at 1:30 AM UTC only weekdays.
+    Default: "cron(30 1 ? * MON-FRI *)"
+
+  StopAt:
+    Type: String
+    Description: ScheduleExpression value e.g., 'cron(30 18 ? * * *)' or 'rate(1 day)'. Default is stop at 6:30 PM UTC daily.
+    Default: "cron(30 18 ? * * *)"
 
 Resources:
   ScalingLambda:
@@ -85,7 +97,7 @@ Resources:
     Properties: 
       Description: Starts at 8 AM on workdays
       Name: StartEcsServicesRule
-      ScheduleExpression: 'cron(30 1 ? * MON-FRI *)' # 8AM MMT
+      ScheduleExpression: !Ref StartAt
       State: ENABLED
       Targets:  
         - Arn: !GetAtt ScalingLambda.Arn
@@ -98,7 +110,7 @@ Resources:
     Properties: 
       Description: Stops at 1 AM on workdays
       Name: StopEcsServicesRule
-      ScheduleExpression: 'cron(30 18 ? * * *)' # 1AM MMT
+      ScheduleExpression: !Ref StopAt
       State: ENABLED
       Targets: 
         - Arn: !GetAtt ScalingLambda.Arn


### PR DESCRIPTION
## Purpose
- Parameterize Schedule Expression

## Overview
- Parameterize Schedule Expression
- Mintor correction in wordings

## Impact
The schedule might stop working.

## Rollback
Revert the PR and redeploy the CloudFormation template

## Test
Tested manually